### PR TITLE
support clipboard in macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ termux-clipboard = "0.1"
 [target.'cfg(target_os="windows")'.dependencies]
 clipboard-win = "4.0.3"
 
-[target.'cfg(not(any(target_os="windows",target_os="android")))'.dependencies]
+[target.'cfg(target_os="macos")'.dependencies]
+clipboard_macos = "0.1"
+
+[target.'cfg(not(any(target_os="windows",target_os="android",target_os="macos")))'.dependencies]
 x11-clipboard = "0.5.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,10 @@ pub use {
     local::LocalClipboard,
 };
 
-// #[cfg(target_os="macos")]
-// pub mod macos;
-// #[cfg(target_os="macos")]
-// pub use macos::{get_string, set_string};
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::MacClipboard;
 
 #[cfg(target_os = "windows")]
 mod win;
@@ -73,9 +73,9 @@ mod termux;
 #[cfg(target_os = "android")]
 pub use termux::TermuxClipboard;
 
-#[cfg(not(any(target_os="windows",target_os="android")))]
+#[cfg(not(any(target_os="windows",target_os="android",target_os="macos")))]
 mod x11;
-#[cfg(not(any(target_os="windows",target_os="android")))]
+#[cfg(not(any(target_os="windows",target_os="android",target_os="macos")))]
 pub use x11::X11Clipboard;
 
 use {
@@ -97,6 +97,14 @@ pub fn new_clipboard() -> Box<dyn Clipboard + Send> {
         return Box::new(WinClipboard::new());
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        // only use MacClipboard after it is verified.
+        if let Ok(clipboard) = MacClipboard::verified() {
+            return Box::new(clipboard);
+        }
+    }
+
     #[cfg(target_os = "android")]
     {
         // we'll use the Termux clipboard, but only after having
@@ -107,7 +115,7 @@ pub fn new_clipboard() -> Box<dyn Clipboard + Send> {
         }
     }
 
-    #[cfg(not(any(target_os="windows",target_os="android")))]
+    #[cfg(not(any(target_os="windows",target_os="android",target_os="macos")))]
     {
         // we'll use the X11 clipboard, but only after having
         // checked it works. As nobody understants X11 anyway,
@@ -154,4 +162,3 @@ mod clipboard_tests {
         assert_eq!(test, get_string().unwrap());
     }
 }
-

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,48 @@
+use crate::{
+    errors::ClipboardError,
+    Clipboard,
+};
+
+pub struct MacClipboard {
+    backend: clipboard_macos::Clipboard,
+}
+
+impl MacClipboard {
+    pub fn new() -> Result<MacClipboard, ClipboardError> {
+        clipboard_macos::Clipboard::new()
+            .map(|backend| Self { backend })
+            .map_err(|e| ClipboardError::from(format!("macOS clipboard error : {}", e)))
+    }
+
+    pub fn verified() -> Result<MacClipboard, ClipboardError> {
+        let mut clipboard = Self::new()?;
+        let previous = clipboard.get_string()?; // saving the old value
+        let test = "test macOS";
+        clipboard.set_string(test)?;
+        let res = clipboard.get_string()?;
+        clipboard.set_string(&previous)?;
+        if res == test.to_string() {
+            Ok(clipboard)
+        } else {
+            Err(ClipboardError::from("non compliand round trip"))
+        }
+    }
+}
+
+impl Clipboard for MacClipboard {
+    fn get_type(&self) -> &'static str {
+        "macOS"
+    }
+
+    fn get_string(&self) -> Result<String, ClipboardError> {
+        self.backend
+            .read()
+            .map_err(|e| ClipboardError::from(format!("macOS clipboard error : {}", e,)))
+    }
+
+    fn set_string(&mut self, s: &str) -> Result<(), ClipboardError> {
+        self.backend
+            .write(s.to_string())
+            .map_err(|e| ClipboardError::from(format!("macOS clipboard error : {}", e,)))
+    }
+}


### PR DESCRIPTION
Hi. I am an intel-based mac user and trying to use broot with clipboard feature. But due to one of the dependencies of `x11-clipboard` named `x11rb` returning `DisplayParsingError`, `copy_path` doesn't work as expected.

This PR aims to fix the clipboard issue in intel-based mac by using another crate [`clipboard_macos`](https://github.com/hecrj/window_clipboard/tree/master/macos). The verb `copy_path` has been tested by running `cargo install --features clipboard --locked --path .` in broot's repo.

Please let me know what you think. Thank you!

reference to DisplayParsingError: <https://support.apple.com/en-us/HT201341>